### PR TITLE
Add onclick to task bar #4

### DIFF
--- a/src/TodoComponent/Todo.js
+++ b/src/TodoComponent/Todo.js
@@ -20,7 +20,10 @@ export default function Todo(props) {
         className="alert  alert-dismissible fade show alertBox w-75 mx-auto shadow-lg todo-color"
         role="alert"
       >
-        <div key={id}>
+        <div 
+          key={id} 
+          onClick={() => props.markComplete(id)}
+        >
           <Form.Check
             className="trigger"
             custom


### PR DESCRIPTION
I was looking through the app and noticed that the only way to complete a todo is to click on the radio button/check box icon. See below.
![Kapture 2020-08-14 at 18 13 14](https://user-images.githubusercontent.com/43709788/90299059-2e187880-de5a-11ea-9855-2c3585a2648a.gif)

This gives the ability to click on bar to complete the todo.

![fullbarcomplete](https://user-images.githubusercontent.com/43709788/90299006-045f5180-de5a-11ea-9d7f-b63111f6dbe0.gif)

Closes #4 